### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/templates

--- a/README.md
+++ b/README.md
@@ -47,7 +47,17 @@ It's also possible to generate a [Custom Element](https://www.w3.org/TR/2016/WD-
 ## How do I contribute?
 
 We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2099,16 +2099,6 @@
         }
       }
     },
-    "eslint-plugin-prettier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.5.0.tgz",
-      "integrity": "sha512-L06bewYpt2Wb8Uk7os8f/0cL5DjddL38t1M/nOpjw5MqVFBn1RIIBBE6tfr37lHUH7AvAubZsvu/bDmNl4RBKQ==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "1.1.2",
-        "jest-docblock": "21.2.0"
-      }
-    },
     "esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -2270,12 +2260,6 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
-    },
-    "fast-diff": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
-      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
-      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3968,12 +3952,6 @@
       "requires": {
         "handlebars": "4.0.11"
       }
-    },
-    "jest-docblock": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-      "dev": true
     },
     "jest-get-type": {
       "version": "21.2.0",
@@ -7916,16 +7894,6 @@
         }
       }
     },
-    "tslint-plugin-prettier": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
-      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
-      "dev": true,
-      "requires": {
-        "eslint-plugin-prettier": "2.5.0",
-        "tslib": "1.8.1"
-      }
-    },
     "tsutils": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-1.9.1.tgz",
@@ -8085,13 +8053,15 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+              "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
               "dev": true,
               "optional": true
             },
             "ajv": {
               "version": "4.11.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+              "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8101,18 +8071,21 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+              "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
               "dev": true
             },
             "aproba": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+              "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
               "dev": true,
               "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8122,42 +8095,49 @@
             },
             "asn1": {
               "version": "0.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+              "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
               "dev": true,
               "optional": true
             },
             "assert-plus": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+              "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
               "dev": true,
               "optional": true
             },
             "asynckit": {
               "version": "0.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+              "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
               "dev": true,
               "optional": true
             },
             "aws-sign2": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
               "dev": true,
               "optional": true
             },
             "aws4": {
               "version": "1.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
               "dev": true,
               "optional": true
             },
             "balanced-match": {
               "version": "0.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+              "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
               "dev": true
             },
             "bcrypt-pbkdf": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+              "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8166,7 +8146,8 @@
             },
             "block-stream": {
               "version": "0.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+              "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
               "dev": true,
               "requires": {
                 "inherits": "2.0.3"
@@ -8174,7 +8155,8 @@
             },
             "boom": {
               "version": "2.10.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+              "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
               "dev": true,
               "requires": {
                 "hoek": "2.16.3"
@@ -8182,7 +8164,8 @@
             },
             "brace-expansion": {
               "version": "1.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+              "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
               "dev": true,
               "requires": {
                 "balanced-match": "0.4.2",
@@ -8191,29 +8174,34 @@
             },
             "buffer-shims": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
               "dev": true
             },
             "caseless": {
               "version": "0.12.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
               "dev": true,
               "optional": true
             },
             "co": {
               "version": "4.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+              "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
               "dev": true,
               "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+              "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
               "dev": true
             },
             "combined-stream": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
               "dev": true,
               "requires": {
                 "delayed-stream": "1.0.0"
@@ -8221,22 +8209,26 @@
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+              "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
               "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
               "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+              "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
               "dev": true
             },
             "cryptiles": {
               "version": "2.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+              "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
               "dev": true,
               "requires": {
                 "boom": "2.10.1"
@@ -8244,7 +8236,8 @@
             },
             "dashdash": {
               "version": "1.14.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+              "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8253,7 +8246,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -8261,7 +8255,8 @@
             },
             "debug": {
               "version": "2.6.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8270,30 +8265,35 @@
             },
             "deep-extend": {
               "version": "0.4.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+              "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
               "dev": true,
               "optional": true
             },
             "delayed-stream": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+              "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
               "dev": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+              "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
               "dev": true,
               "optional": true
             },
             "detect-libc": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+              "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
               "dev": true,
               "optional": true
             },
             "ecc-jsbn": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+              "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8302,24 +8302,28 @@
             },
             "extend": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+              "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
               "dev": true,
               "optional": true
             },
             "extsprintf": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+              "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
               "dev": true
             },
             "forever-agent": {
               "version": "0.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
               "dev": true,
               "optional": true
             },
             "form-data": {
               "version": "2.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8330,12 +8334,14 @@
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
               "dev": true
             },
             "fstream": {
               "version": "1.0.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
               "dev": true,
               "requires": {
                 "graceful-fs": "4.1.11",
@@ -8346,7 +8352,8 @@
             },
             "fstream-ignore": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8357,7 +8364,8 @@
             },
             "gauge": {
               "version": "2.7.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8373,7 +8381,8 @@
             },
             "getpass": {
               "version": "0.1.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+              "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8382,7 +8391,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -8390,7 +8400,8 @@
             },
             "glob": {
               "version": "7.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+              "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
                 "fs.realpath": "1.0.0",
@@ -8403,18 +8414,21 @@
             },
             "graceful-fs": {
               "version": "4.1.11",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
               "dev": true
             },
             "har-schema": {
               "version": "1.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+              "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
               "dev": true,
               "optional": true
             },
             "har-validator": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8424,13 +8438,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+              "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
               "dev": true,
               "optional": true
             },
             "hawk": {
               "version": "3.1.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
               "dev": true,
               "requires": {
                 "boom": "2.10.1",
@@ -8441,12 +8457,14 @@
             },
             "hoek": {
               "version": "2.16.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+              "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
               "dev": true
             },
             "http-signature": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8457,7 +8475,8 @@
             },
             "inflight": {
               "version": "1.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
               "dev": true,
               "requires": {
                 "once": "1.4.0",
@@ -8466,18 +8485,21 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             },
             "ini": {
               "version": "1.3.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+              "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
               "dev": true,
               "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
                 "number-is-nan": "1.0.1"
@@ -8485,24 +8507,28 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
               "dev": true,
               "optional": true
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
               "dev": true
             },
             "isstream": {
               "version": "0.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
               "dev": true,
               "optional": true
             },
             "jodid25519": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+              "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8511,19 +8537,22 @@
             },
             "jsbn": {
               "version": "0.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+              "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
               "dev": true,
               "optional": true
             },
             "json-schema": {
               "version": "0.2.3",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+              "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
               "dev": true,
               "optional": true
             },
             "json-stable-stringify": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+              "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8532,19 +8561,22 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
               "dev": true,
               "optional": true
             },
             "jsonify": {
               "version": "0.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
               "dev": true,
               "optional": true
             },
             "jsprim": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+              "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8556,7 +8588,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -8564,12 +8597,14 @@
             },
             "mime-db": {
               "version": "1.27.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+              "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
               "dev": true
             },
             "mime-types": {
               "version": "2.1.15",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+              "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
               "dev": true,
               "requires": {
                 "mime-db": "1.27.0"
@@ -8577,7 +8612,8 @@
             },
             "minimatch": {
               "version": "3.0.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
                 "brace-expansion": "1.1.7"
@@ -8585,12 +8621,14 @@
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
               "dev": true
             },
             "mkdirp": {
               "version": "0.5.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
               "requires": {
                 "minimist": "0.0.8"
@@ -8598,13 +8636,15 @@
             },
             "ms": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
               "dev": true,
               "optional": true
             },
             "node-pre-gyp": {
               "version": "0.6.39",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+              "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8623,7 +8663,8 @@
             },
             "nopt": {
               "version": "4.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+              "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8633,7 +8674,8 @@
             },
             "npmlog": {
               "version": "4.1.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+              "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8645,24 +8687,28 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
               "dev": true
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
               "dev": true,
               "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+              "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
               "dev": true,
               "optional": true
             },
             "once": {
               "version": "1.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
               "requires": {
                 "wrappy": "1.0.2"
@@ -8670,19 +8716,22 @@
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
               "dev": true,
               "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
               "dev": true,
               "optional": true
             },
             "osenv": {
               "version": "0.1.4",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8692,35 +8741,41 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
               "dev": true
             },
             "performance-now": {
               "version": "0.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
               "dev": true,
               "optional": true
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
               "dev": true
             },
             "punycode": {
               "version": "1.4.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+              "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
               "dev": true,
               "optional": true
             },
             "qs": {
               "version": "6.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
               "dev": true,
               "optional": true
             },
             "rc": {
               "version": "1.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+              "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8732,7 +8787,8 @@
               "dependencies": {
                 "minimist": {
                   "version": "1.2.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
                   "dev": true,
                   "optional": true
                 }
@@ -8740,7 +8796,8 @@
             },
             "readable-stream": {
               "version": "2.2.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+              "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
               "dev": true,
               "requires": {
                 "buffer-shims": "1.0.0",
@@ -8754,7 +8811,8 @@
             },
             "request": {
               "version": "2.81.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+              "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8784,7 +8842,8 @@
             },
             "rimraf": {
               "version": "2.6.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+              "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
               "dev": true,
               "requires": {
                 "glob": "7.1.2"
@@ -8792,30 +8851,35 @@
             },
             "safe-buffer": {
               "version": "5.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
               "dev": true
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+              "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
               "dev": true,
               "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
               "dev": true,
               "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+              "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
               "dev": true,
               "optional": true
             },
             "sntp": {
               "version": "1.0.9",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+              "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
               "dev": true,
               "requires": {
                 "hoek": "2.16.3"
@@ -8823,7 +8887,8 @@
             },
             "sshpk": {
               "version": "1.13.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+              "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8840,7 +8905,8 @@
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "bundled": true,
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                  "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
                   "dev": true,
                   "optional": true
                 }
@@ -8848,7 +8914,8 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
@@ -8858,7 +8925,8 @@
             },
             "string_decoder": {
               "version": "1.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+              "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
               "dev": true,
               "requires": {
                 "safe-buffer": "5.0.1"
@@ -8866,13 +8934,15 @@
             },
             "stringstream": {
               "version": "0.0.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
               "dev": true,
               "optional": true
             },
             "strip-ansi": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
               "requires": {
                 "ansi-regex": "2.1.1"
@@ -8880,13 +8950,15 @@
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+              "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
               "dev": true,
               "optional": true
             },
             "tar": {
               "version": "2.2.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
               "dev": true,
               "requires": {
                 "block-stream": "0.0.9",
@@ -8896,7 +8968,8 @@
             },
             "tar-pack": {
               "version": "3.4.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+              "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8912,7 +8985,8 @@
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8921,7 +8995,8 @@
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8930,30 +9005,35 @@
             },
             "tweetnacl": {
               "version": "0.14.5",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+              "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
               "dev": true,
               "optional": true
             },
             "uid-number": {
               "version": "0.0.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+              "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
               "dev": true,
               "optional": true
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
               "dev": true
             },
             "uuid": {
               "version": "3.0.1",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
               "dev": true,
               "optional": true
             },
             "verror": {
               "version": "1.3.6",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+              "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8962,7 +9042,8 @@
             },
             "wide-align": {
               "version": "1.1.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+              "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
               "dev": true,
               "optional": true,
               "requires": {
@@ -8971,7 +9052,8 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
               "dev": true
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli-create-widget",
-  "version": "0.1.1",
+  "version": "0.1.2-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -18,21 +18,24 @@
       }
     },
     "@dojo/core": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
-      "integrity": "sha512-SnmiQcbPUqtjzy1sOmkLvg3C6UFUaXDNUNqHzGaF2QM1Ebp1Lw+j+BE+E6uJgxISlgckjAZ6myjwFI+obZ316w==",
-      "dev": true
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-0.3.1.tgz",
+      "integrity": "sha512-PEwqxpsuTTG0b2wwy0TLHEFf/R6ZBE4zizo4EXzGUVRc5O44w5Hbn+NN48v/o8hwQRKxmX3ywLI0Z1CMZ6NM6w==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.8.1"
+      }
     },
     "@dojo/has": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.1.tgz",
-      "integrity": "sha512-McwwBLpM0R0zsIy0+1WkHFXYYNalMOPJydqW3dd089K+AaOCto4AtFKA6+GDEuXDgJE9cMG5tX48hFwIL3dtxQ==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-0.1.2.tgz",
+      "integrity": "sha512-122xXU9xHjG/EayITIAiIdKVphZTZ2wM9IEBArarkBQzXZP1shGAbTJq7NHWUoTemw48tvTxr+OOi7wVCm7IXg==",
       "dev": true
     },
     "@dojo/interfaces": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
-      "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+      "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
       "dev": true,
       "requires": {
         "@types/yargs": "8.0.3"
@@ -45,9 +48,9 @@
       "dev": true
     },
     "@dojo/shim": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
-      "integrity": "sha512-DzpD1D90D1vsHuqPqGb78JFfykf0Nvbel+iAupYVPEwq+LVxAZPDC8nGZRsAaVfWSsFLuKPcbRRIInf+emCFAw==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.5.tgz",
+      "integrity": "sha512-RhUPwaMmxWRTTKA3rO5gwRwRvoyVZNRsZMsQof852AwZq2bReUOYy4K9Ed6wF5SKQrJngVxNxiaGFddaZLLwSg==",
       "dev": true,
       "requires": {
         "intersection-observer": "0.4.3",
@@ -61,13 +64,21 @@
       "integrity": "sha512-BTcYNMxOnGlTEaOYqab9WygE2sLz9ZRWRsuTwUttceewzEDn/Ok/4lWdIgwwX+bb3MybvFPU1wBkq8Co+Bfqyw==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.0",
-        "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
-        "@dojo/shim": "0.2.3",
+        "@dojo/core": "0.3.1",
+        "@dojo/has": "0.1.2",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "0.2.5",
         "decompress": "4.2.0",
         "semver": "5.4.1",
         "tslib": "1.8.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        }
       }
     },
     "@theintern/leadfoot": {
@@ -76,19 +87,19 @@
       "integrity": "sha512-J9wLAMjAU+Wyv5jGmHdVN4xnuyaD24kK7mAoLUPBLRNxflkJoTo9Ph5g4BKUHp+xpKd/IMU00ulgMMf++Xqm4A==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.0",
-        "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
-        "@dojo/shim": "0.2.3",
+        "@dojo/core": "0.3.1",
+        "@dojo/has": "0.1.2",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "0.2.5",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
         "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
-      "version": "6.25.2",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
-      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.0.tgz",
+      "integrity": "sha512-PyWcbX0W4r4GcgXLI0Vu4jyJ/Erueo3PwjgvQcOmWAOBW0ObhzBBciEX+sHvjkNE0umI6nqD192FDKvYZTL91A==",
       "dev": true
     },
     "@types/benchmark": {
@@ -104,13 +115,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.96"
       }
     },
     "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/chalk": {
@@ -125,7 +136,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.96"
       }
     },
     "@types/diff": {
@@ -135,9 +146,15 @@
       "dev": true
     },
     "@types/ejs": {
-      "version": "2.3.33",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-2.3.33.tgz",
-      "integrity": "sha1-Ck4Keu7gmUQVSwbOWirGoRj5KwA=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-2.5.0.tgz",
+      "integrity": "sha512-mm6fwe7oF2ltOovvKf4ulneGAERJJOo4BFgp5cKDG194byeFOdTpB8Tsuqa9MGJeNydd/D5eh4vmYFOYylR8Rw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
       "dev": true
     },
     "@types/express": {
@@ -147,17 +164,18 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.1",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.57",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
-      "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
+      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/events": "1.1.0",
+        "@types/node": "6.0.96"
       }
     },
     "@types/fs-extra": {
@@ -166,17 +184,18 @@
       "integrity": "sha1-Tv8v9bBqWjv8VErdOm7TTN+JIzU=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.96"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.35",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.35.tgz",
+      "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "6.0.92"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "6.0.96"
       }
     },
     "@types/grunt": {
@@ -185,7 +204,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.96"
       }
     },
     "@types/handlebars": {
@@ -219,14 +238,22 @@
       "dev": true
     },
     "@types/istanbul-lib-instrument": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
-      "integrity": "sha512-BWj7zRtwVU5KzuYL/zNuVoSvYWIpT02smNMpQwQbJjwEyITEGSKsxVIT4b2bzXCWFMq76ss0sdY/5yw3NwTlIA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
+      "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "6.25.2",
+        "@types/babel-types": "7.0.0",
         "@types/istanbul-lib-coverage": "1.1.0",
-        "@types/source-map": "0.1.29"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@types/istanbul-lib-report": {
@@ -239,13 +266,21 @@
       }
     },
     "@types/istanbul-lib-source-maps": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
-      "integrity": "sha512-GxjyOSIZC/HETEo61MOjM72qdZH0F9UwfuXCKhmgqhVC7PSjE61BU2I/2eZwQ43+kSdkxKvnOBqqNZi1HHHNEA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+      "integrity": "sha512-K0IvmTFbI2GjLG0O4AOLPV2hFItE5Bg/TY41IBZIThhLhYthJc3VjpZpM8/sIaIVtnQcX8b2k3muPDvsvhk+Fg==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "1.1.0",
-        "@types/source-map": "0.1.29"
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "@types/istanbul-reports": {
@@ -265,9 +300,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.88",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.88.tgz",
-      "integrity": "sha512-S+7dONqCP8kXqOPCPxra7Vw8FndWS8pNfVkClMSzRCPMjXkA3BaI3ybMBCiSd4y+r1vC49UEjNthnm+fO8J/dw==",
+      "version": "4.14.96",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.96.tgz",
+      "integrity": "sha512-9QQXhOGVLTW+ALWBXMBKlXWsBnWfCPYX7NjgVhPUZGqJNad0jtAfqKgBh56uVPm2XUmh9IIAkadJmJoGhEpJYA==",
       "dev": true
     },
     "@types/marked": {
@@ -289,9 +324,9 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/mockery": {
@@ -301,9 +336,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.92",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.92.tgz",
-      "integrity": "sha512-awEYSSTn7dauwVCYSx2CJaPTu0Z1Ht2oR1b2AD3CYao6ZRb+opb6EL43fzmD7eMFgMHzTBWSUzlWSD+S8xN0Nw==",
+      "version": "6.0.96",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.96.tgz",
+      "integrity": "sha512-fsOOY6tMQ3jCB2wD51XFDmmpgm4wVKkJECdcVRqapbJEa7awJDcr+SaH8toz+4r4KW8YQ3M7ybXMoSDo1QGewA==",
       "dev": true
     },
     "@types/platform": {
@@ -318,7 +353,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.96"
       }
     },
     "@types/serve-static": {
@@ -327,7 +362,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.0.57",
+        "@types/express-serve-static-core": "4.11.1",
         "@types/mime": "2.0.0"
       }
     },
@@ -343,7 +378,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.96"
       }
     },
     "@types/sinon": {
@@ -370,7 +405,7 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.92"
+        "@types/node": "6.0.96"
       }
     },
     "@types/yargs": {
@@ -456,6 +491,30 @@
         "string-width": "2.1.1"
       }
     },
+    "ansi-cyan": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-cyan/-/ansi-cyan-0.1.1.tgz",
+      "integrity": "sha1-U4rlKK+JgvKK4w2G8vF0VtJgmHM=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -465,6 +524,18 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
+      "dev": true
     },
     "any-promise": {
       "version": "1.3.0",
@@ -481,6 +552,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -515,10 +592,10 @@
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
-    "array-differ": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+    "arr-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-2.1.0.tgz",
+      "integrity": "sha1-IPnqtexw9cfSFbEHexw5Fh0pLH0=",
       "dev": true
     },
     "array-filter": {
@@ -549,6 +626,12 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
+    "array-slice": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+      "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
       "dev": true
     },
     "array-uniq": {
@@ -584,9 +667,9 @@
       "optional": true
     },
     "assertion-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
     "async": {
@@ -615,7 +698,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000780",
+        "caniuse-db": "1.0.30000795",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -679,14 +762,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -789,12 +872,6 @@
       "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg=",
       "dev": true
     },
-    "beeper": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-      "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-      "dev": true
-    },
     "benchmark": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
@@ -802,7 +879,7 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "platform": "1.3.4"
+        "platform": "1.3.5"
       },
       "dependencies": {
         "lodash": {
@@ -849,7 +926,7 @@
         "bytes": "2.2.0",
         "content-type": "1.0.4",
         "debug": "2.2.0",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "http-errors": "1.3.1",
         "iconv-lite": "0.4.13",
         "on-finished": "2.3.0",
@@ -965,8 +1042,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000780",
-        "electron-to-chromium": "1.3.28"
+        "caniuse-db": "1.0.30000795",
+        "electron-to-chromium": "1.3.31"
       }
     },
     "buffer": {
@@ -1029,15 +1106,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000780",
+        "caniuse-db": "1.0.30000795",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000780",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000780.tgz",
-      "integrity": "sha1-jRl3Vh0A/w8O0ra2YUAyirRQTAo=",
+      "version": "1.0.30000795",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000795.tgz",
+      "integrity": "sha1-ZE8D+rAN2L0Wk+Xh5w2Gsxxc/s4=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1069,12 +1146,12 @@
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.0.2",
+        "assertion-error": "1.1.0",
         "check-error": "1.0.2",
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.7"
       }
     },
     "chalk": {
@@ -1121,6 +1198,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1149,6 +1232,38 @@
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.2.0.tgz",
       "integrity": "sha1-hQeHN5E7iA9uyf/ntl6D7Hd2KE8="
     },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
+    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -1174,12 +1289,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
       "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
-      "dev": true
-    },
-    "clone-stats": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-      "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
     },
     "coa": {
@@ -1385,6 +1494,45 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -1437,7 +1585,7 @@
       "requires": {
         "es6-promise": "2.3.0",
         "lodash": "3.10.1",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "xml2js": "0.4.19"
       },
       "dependencies": {
@@ -1617,6 +1765,12 @@
         "array-find-index": "1.0.2"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1721,13 +1875,19 @@
         }
       }
     },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.5"
+        "type-detect": "4.0.7"
       }
     },
     "deep-equal": {
@@ -1771,9 +1931,9 @@
       "optional": true
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
     "destroy": {
@@ -1838,29 +1998,6 @@
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
-    "duplexer2": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        }
-      }
-    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -1879,9 +2016,15 @@
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "electron-to-chromium": {
-      "version": "1.3.28",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.28.tgz",
-      "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
+      "version": "1.3.31",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.31.tgz",
+      "integrity": "sha512-XE4CLbswkZgZFn34cKFy1xaX+F5LHxeDLjY1+rsK9asDzknhbrd9g/n/01/acbU25KTsUSiLKwvlLyA+6XLUOA==",
+      "dev": true
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
     "emojis-list": {
@@ -1891,15 +2034,15 @@
       "dev": true
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-      "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "dev": true,
       "requires": {
         "once": "1.4.0"
@@ -1954,6 +2097,16 @@
             "amdefine": "1.0.1"
           }
         }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.5.0.tgz",
+      "integrity": "sha512-L06bewYpt2Wb8Uk7os8f/0cL5DjddL38t1M/nOpjw5MqVFBn1RIIBBE6tfr37lHUH7AvAubZsvu/bDmNl4RBKQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
       }
     },
     "esprima": {
@@ -2042,8 +2195,8 @@
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
-        "encodeurl": "1.0.1",
+        "depd": "1.1.2",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "finalhandler": "1.0.6",
@@ -2118,15 +2271,11 @@
         "is-extglob": "1.0.0"
       }
     },
-    "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "time-stamp": "1.1.0"
-      }
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2156,6 +2305,16 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2196,7 +2355,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
@@ -2226,6 +2385,12 @@
           "dev": true
         }
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2328,7 +2493,7 @@
     },
     "fs-extra": {
       "version": "0.30.0",
-      "resolved": "http://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
       "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
       "requires": {
         "graceful-fs": "4.1.11",
@@ -2387,6 +2552,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -2517,15 +2688,6 @@
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         }
-      }
-    },
-    "glogg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-      "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
       }
     },
     "got": {
@@ -2691,7 +2853,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.4",
+        "intern": "4.1.5",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -2701,7 +2863,7 @@
         "postcss-cssnext": "2.11.0",
         "postcss-import": "9.1.0",
         "postcss-modules": "0.6.4",
-        "remap-istanbul": "0.9.5",
+        "remap-istanbul": "0.10.1",
         "resolve-from": "2.0.0",
         "shelljs": "0.7.8",
         "tslint": "4.5.1",
@@ -2710,11 +2872,40 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
+          }
         }
       }
     },
@@ -2822,7 +3013,7 @@
         "lodash": "2.4.1",
         "ncp": "0.5.1",
         "rimraf": "2.2.6",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "strip-bom": "2.0.0",
         "typescript": "1.8.9",
         "underscore": "1.5.1",
@@ -2856,9 +3047,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -2868,76 +3059,6 @@
       "dev": true,
       "requires": {
         "typings-core": "1.6.1"
-      }
-    },
-    "gulp-util": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.7.tgz",
-      "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
-      "dev": true,
-      "requires": {
-        "array-differ": "1.0.0",
-        "array-uniq": "1.0.3",
-        "beeper": "1.1.1",
-        "chalk": "1.1.3",
-        "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
-        "gulplog": "1.0.0",
-        "has-gulplog": "0.1.0",
-        "lodash._reescape": "3.0.0",
-        "lodash._reevaluate": "3.0.0",
-        "lodash._reinterpolate": "3.0.0",
-        "lodash.template": "3.6.2",
-        "minimist": "1.2.0",
-        "multipipe": "0.1.2",
-        "object-assign": "3.0.0",
-        "replace-ext": "0.0.1",
-        "through2": "2.0.1",
-        "vinyl": "0.5.3"
-      },
-      "dependencies": {
-        "lodash.template": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-          "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-          "dev": true,
-          "requires": {
-            "lodash._basecopy": "3.0.1",
-            "lodash._basetostring": "3.0.1",
-            "lodash._basevalues": "3.0.0",
-            "lodash._isiterateecall": "3.0.9",
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.escape": "3.2.0",
-            "lodash.keys": "3.1.2",
-            "lodash.restparam": "3.6.1",
-            "lodash.templatesettings": "3.1.1"
-          }
-        },
-        "lodash.templatesettings": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-          "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-          "dev": true,
-          "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.escape": "3.2.0"
-          }
-        },
-        "object-assign": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-          "dev": true
-        }
-      }
-    },
-    "gulplog": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-      "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-      "dev": true,
-      "requires": {
-        "glogg": "1.0.0"
       }
     },
     "handlebars": {
@@ -2991,15 +3112,6 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
       "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
       "dev": true
-    },
-    "has-gulplog": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-      "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-      "dev": true,
-      "requires": {
-        "sparkles": "1.0.0"
-      }
     },
     "hawk": {
       "version": "1.1.1",
@@ -3103,6 +3215,31 @@
         "extend": "3.0.1"
       }
     },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.1.0",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
@@ -3175,30 +3312,30 @@
       "dev": true
     },
     "intern": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.4.tgz",
-      "integrity": "sha512-QL5+pVjpjNVtp5mB2QwTgf3fuG3l+lA3UzhHTxjhahWt0Z84LfdFfHFXN6UeB72IYQq7LDhjStO6I51rsTjb6Q==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.5.tgz",
+      "integrity": "sha512-wY3xxstQ2zHpOU/ktjMcyvzmzazyjvlcipD79RqDGm+kyMdJcyI+00qfHvPlzrwhGwX+XVs2+tqwJCiSMKzYUg==",
       "dev": true,
       "requires": {
-        "@dojo/core": "0.3.0",
-        "@dojo/has": "0.1.1",
-        "@dojo/interfaces": "0.2.0",
-        "@dojo/shim": "0.2.3",
+        "@dojo/core": "0.3.1",
+        "@dojo/has": "0.1.2",
+        "@dojo/interfaces": "0.2.1",
+        "@dojo/shim": "0.2.5",
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.8",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
         "@types/http-errors": "1.5.34",
         "@types/istanbul-lib-coverage": "1.1.0",
         "@types/istanbul-lib-hook": "1.0.0",
-        "@types/istanbul-lib-instrument": "1.7.0",
+        "@types/istanbul-lib-instrument": "1.7.1",
         "@types/istanbul-lib-report": "1.1.0",
-        "@types/istanbul-lib-source-maps": "1.2.0",
+        "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.88",
+        "@types/lodash": "4.14.96",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3223,7 +3360,7 @@
         "lodash": "4.17.4",
         "mime-types": "2.1.17",
         "minimatch": "3.0.4",
-        "platform": "1.3.4",
+        "platform": "1.3.5",
         "resolve": "1.4.0",
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
@@ -3241,7 +3378,7 @@
             "bytes": "2.4.0",
             "content-type": "1.0.4",
             "debug": "2.6.7",
-            "depd": "1.1.1",
+            "depd": "1.1.2",
             "http-errors": "1.6.2",
             "iconv-lite": "0.4.15",
             "on-finished": "2.3.0",
@@ -3281,6 +3418,14 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
             "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            }
           }
         },
         "iconv-lite": {
@@ -3423,6 +3568,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3508,6 +3668,15 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3535,10 +3704,22 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
@@ -3723,7 +3904,7 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "istanbul-lib-report": {
@@ -3788,10 +3969,71 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.2.tgz",
+      "integrity": "sha512-lLkz3IRPTNeATsKQGeltbzRK/5+bWsXBHfpZrxJAi4N30RtCtNA+rJznp4uR2+4OgkBsoeeFwONVLr4gzIVErQ==",
       "dev": true
     },
     "js-tokens": {
@@ -3925,6 +4167,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -3944,16 +4192,272 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.13.0",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
       "dev": true
     },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.6",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "cli-spinners": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+          "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+          "dev": true
+        },
+        "ora": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+          "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-spinners": "0.1.2",
+            "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
+    },
     "livereload-js": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.2.2.tgz",
-      "integrity": "sha1-bIclfmSKtHW8JOoldFftzB+NC8I=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
+      "integrity": "sha512-j1R0/FeGa64Y+NmqfZhyoVRzcFlOZ8sNlKzHjh4VvLULFACZhn68XrX5DFg2FhMvSMJmROuFxRSa560ECWKBMg==",
       "dev": true
     },
     "load-json-file": {
@@ -4011,58 +4515,10 @@
       "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
       "dev": true
     },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basetostring": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-      "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-      "dev": true
-    },
-    "lodash._basevalues": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-      "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-      "dev": true
-    },
-    "lodash._reescape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-      "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-      "dev": true
-    },
-    "lodash._reevaluate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-      "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-      "dev": true
-    },
     "lodash._reinterpolate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-      "dev": true
-    },
-    "lodash._root": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-      "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
       "dev": true
     },
     "lodash.assign": {
@@ -4071,48 +4527,10 @@
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
-    "lodash.escape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-      "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-      "dev": true,
-      "requires": {
-        "lodash._root": "3.0.1"
-      }
-    },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true,
-      "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
-      }
-    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-      "dev": true
-    },
-    "lodash.restparam": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-      "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
       "dev": true
     },
     "lodash.template": {
@@ -4146,6 +4564,16 @@
       "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
       "requires": {
         "chalk": "1.1.3"
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
       }
     },
     "lolex": {
@@ -4218,9 +4646,9 @@
       }
     },
     "make-error": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
-      "integrity": "sha1-Uq06M5zPEM5itAQLcI/nByRLi5Y=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.2.tgz",
+      "integrity": "sha512-l9ra35l5VWLF24y75Tg8XgfGLX0ueRhph118WKM6H5denx4bB5QF59+4UAm9oJ2qsPQZas/CQUDdtDdfvYHBdQ==",
       "dev": true
     },
     "make-error-cause": {
@@ -4229,7 +4657,7 @@
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "dev": true,
       "requires": {
-        "make-error": "1.3.0"
+        "make-error": "1.3.2"
       }
     },
     "map-obj": {
@@ -4239,9 +4667,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.7.tgz",
-      "integrity": "sha512-zBEP4qO1YQp5aXHt8S5wTiOv9i2X74V/LQL0zhUNvVaklt6Ywa6lChxIvS+ibYlCGgADwKwZFhjC3+XfpsvQvQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -4395,15 +4823,6 @@
       "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
       "dev": true
     },
-    "multipipe": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-      "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "0.0.2"
-      }
-    },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
@@ -4446,7 +4865,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
+        "semver": "5.5.0",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -4477,6 +4896,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",
+      "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
+      "dev": true,
+      "requires": {
+        "which": "1.3.0"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
@@ -4484,6 +4912,25 @@
       "dev": true,
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.13.0",
+        "npm-path": "2.0.4",
+        "which": "1.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
+          "integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -4706,10 +5153,13 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "dev": true,
+      "requires": {
+        "p-try": "1.0.0"
+      }
     },
     "p-locate": {
       "version": "2.0.0",
@@ -4717,8 +5167,20 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "1.2.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -4729,7 +5191,7 @@
         "got": "6.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "pako": {
@@ -4899,9 +5361,9 @@
       }
     },
     "platform": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
-      "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0=",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
       "dev": true
     },
     "pleeease-filters": {
@@ -4912,6 +5374,46 @@
       "requires": {
         "onecolor": "2.4.2",
         "postcss": "5.2.18"
+      }
+    },
+    "plugin-error": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
+      "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
+      "dev": true,
+      "requires": {
+        "ansi-cyan": "0.1.1",
+        "ansi-red": "0.1.1",
+        "arr-diff": "1.1.0",
+        "arr-union": "2.1.0",
+        "extend-shallow": "1.1.4"
+      },
+      "dependencies": {
+        "arr-diff": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
+          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "1.1.0",
+            "array-slice": "0.2.3"
+          }
+        },
+        "extend-shallow": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-1.1.4.tgz",
+          "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
+          "dev": true,
+          "requires": {
+            "kind-of": "1.1.0"
+          }
+        },
+        "kind-of": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
+          "dev": true
+        }
       }
     },
     "popsicle": {
@@ -5006,7 +5508,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "js-base64": "2.4.0",
+        "js-base64": "2.4.2",
         "source-map": "0.5.7",
         "supports-color": "3.2.3"
       },
@@ -5364,7 +5866,7 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14",
+        "postcss": "6.0.16",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
@@ -5386,6 +5888,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5395,14 +5908,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5412,9 +5925,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5563,7 +6076,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.14"
+        "postcss": "6.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5584,6 +6097,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5593,14 +6117,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5610,9 +6134,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5627,7 +6151,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5648,6 +6172,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5657,14 +6192,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5674,9 +6209,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5691,7 +6226,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5712,6 +6247,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5721,14 +6267,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5738,9 +6284,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5755,7 +6301,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.14"
+        "postcss": "6.0.16"
       },
       "dependencies": {
         "ansi-styles": {
@@ -5776,6 +6322,17 @@
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "4.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+              "dev": true,
+              "requires": {
+                "has-flag": "2.0.0"
+              }
+            }
           }
         },
         "has-flag": {
@@ -5785,14 +6342,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.14",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
-          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "version": "6.0.16",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.16.tgz",
+          "integrity": "sha512-m758RWPmSjFH/2MyyG3UOW1fgYbR9rtdzz5UNJnlm7OLtu4B2h9C6gi+bE4qFKghsBRFfZT8NzoQBs6JhLotoA==",
           "dev": true,
           "requires": {
             "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.5.0"
+            "supports-color": "5.1.0"
           }
         },
         "source-map": {
@@ -5802,9 +6359,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
+          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6028,6 +6585,39 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -6182,9 +6772,9 @@
       }
     },
     "rc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
-      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.4.tgz",
+      "integrity": "sha1-oPYGyq4qO4YrvQ74VILAElsxX6M=",
       "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
@@ -6326,9 +6916,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -6357,7 +6947,7 @@
       "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2",
+        "rc": "1.2.4",
         "safe-buffer": "5.1.1"
       }
     },
@@ -6367,7 +6957,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.2"
+        "rc": "1.2.4"
       }
     },
     "regjsgen": {
@@ -6394,17 +6984,25 @@
       }
     },
     "remap-istanbul": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.9.5.tgz",
-      "integrity": "sha1-oYYXsfMe7Fp9vud1OCmLd1YGqqg=",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.1.tgz",
+      "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
       "dev": true,
       "requires": {
         "amdefine": "1.0.1",
-        "gulp-util": "3.0.7",
         "istanbul": "0.4.5",
         "minimatch": "3.0.4",
-        "source-map": "0.5.7",
+        "plugin-error": "0.1.2",
+        "source-map": "0.6.1",
         "through2": "2.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
@@ -6434,12 +7032,6 @@
         "is-finite": "1.0.2"
       }
     },
-    "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-      "dev": true
-    },
     "request": {
       "version": "2.42.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
@@ -6467,6 +7059,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
       "dev": true
     },
     "require-main-filename": {
@@ -6535,6 +7133,23 @@
         "glob": "7.1.2"
       }
     },
+    "rxjs": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
+      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -6563,9 +7178,9 @@
       }
     },
     "semver": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
       "dev": true
     },
     "semver-diff": {
@@ -6574,7 +7189,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "5.4.1"
+        "semver": "5.5.0"
       }
     },
     "send": {
@@ -6584,9 +7199,9 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "fresh": "0.5.2",
@@ -6617,6 +7232,14 @@
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
             "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            }
           }
         },
         "mime": {
@@ -6645,7 +7268,7 @@
       "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
         "send": "0.15.6"
@@ -6731,6 +7354,12 @@
         "util": "0.10.3"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -6760,12 +7389,6 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "sparkles": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-      "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
       "dev": true
     },
     "spdx-correct": {
@@ -6804,6 +7427,12 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -6817,6 +7446,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -6869,6 +7507,17 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -6956,6 +7605,12 @@
         }
       }
     },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
+    },
     "tape": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tape/-/tape-2.3.0.tgz",
@@ -6979,7 +7634,7 @@
       "dev": true,
       "requires": {
         "bl": "1.2.1",
-        "end-of-stream": "1.4.0",
+        "end-of-stream": "1.4.1",
         "readable-stream": "2.3.3",
         "xtend": "4.0.1"
       },
@@ -7145,12 +7800,6 @@
         "any-promise": "1.3.0"
       }
     },
-    "time-stamp": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-      "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-      "dev": true
-    },
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
@@ -7166,7 +7815,7 @@
         "body-parser": "1.14.2",
         "debug": "2.2.0",
         "faye-websocket": "0.10.0",
-        "livereload-js": "2.2.2",
+        "livereload-js": "2.3.0",
         "parseurl": "1.3.2",
         "qs": "5.1.0"
       },
@@ -7233,9 +7882,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -7244,9 +7893,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.5.0",
+        "tslib": "1.8.1",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
@@ -7254,7 +7904,26 @@
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
           "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
           "dev": true
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.5.0",
+        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -7279,9 +7948,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
+      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
       "dev": true
     },
     "type-is": {
@@ -8477,7 +9146,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.88",
+        "@types/lodash": "4.14.96",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -8485,7 +9154,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.4",
-        "marked": "0.3.7",
+        "marked": "0.3.12",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",
@@ -8499,7 +9168,7 @@
           "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
           "dev": true,
           "requires": {
-            "@types/node": "6.0.92"
+            "@types/node": "6.0.96"
           }
         },
         "@types/minimatch": {
@@ -8598,7 +9267,7 @@
         "popsicle-rewrite": "1.0.0",
         "popsicle-status": "2.0.1",
         "promise-finally": "2.2.1",
-        "rc": "1.2.2",
+        "rc": "1.2.4",
         "rimraf": "2.6.2",
         "sort-keys": "1.1.2",
         "string-template": "1.0.0",
@@ -8918,17 +9587,6 @@
       "resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
       "integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
       "dev": true
-    },
-    "vinyl": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-      "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-      "dev": true,
-      "requires": {
-        "clone": "1.0.3",
-        "clone-stats": "0.0.1",
-        "replace-ext": "0.0.1"
-      }
     },
     "websocket-driver": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "url": "https://github.com/dojo/cli-create-widget.git"
   },
   "scripts": {
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "devDependencies": {
@@ -44,9 +46,15 @@
     "glob": "^7.0.3",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
     "mockery": "^1.7.0",
+    "prettier": "1.9.2",
     "sinon": "^1.17.5",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1",
     "yargs": "^5.0.0"
   },
@@ -58,5 +66,19 @@
     "fs-extra": "^0.30.0",
     "ora": "^0.3.0",
     "pkg-dir": "^1.0.0"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "prettier": "1.9.2",
     "sinon": "^1.17.5",
     "tslint": "5.2.0",
-    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1",
     "yargs": "^5.0.0"
   },

--- a/src/register.ts
+++ b/src/register.ts
@@ -12,7 +12,7 @@ export default function(options: OptionsHelper): void {
 		alias: 'styles',
 		defaultDescription: '<component_folder>/styles',
 		demand: false,
-		describe: 'The location of your widget\'s styles',
+		describe: "The location of your widget's styles",
 		requiresArg: true,
 		type: 'string'
 	});
@@ -20,7 +20,7 @@ export default function(options: OptionsHelper): void {
 		alias: 'tests',
 		defaultDescription: '<component_folder>/tests',
 		demand: false,
-		describe: 'The location of your widget\'s tests',
+		describe: "The location of your widget's tests",
 		requiresArg: true,
 		type: 'string'
 	});

--- a/src/run.ts
+++ b/src/run.ts
@@ -29,7 +29,7 @@ export interface CreateWidgetArgs extends Argv {
 }
 
 function getDirectoryNames(args: CreateWidgetArgs, folderName: string) {
-	const dirs = [ folderName ];
+	const dirs = [folderName];
 
 	if (!args.styles) {
 		dirs.push(`${folderName}/styles`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,12 +1,9 @@
 import { Argv } from 'yargs';
 import { Helper } from '@dojo/interfaces/cli';
-import { join, relative, resolve } from 'path';
+import { join, relative } from 'path';
 import * as chalk from 'chalk';
 import createDir from '@dojo/cli-create-app/createDir';
 import renderFiles from '@dojo/cli-create-app/renderFiles';
-
-import register from './register';
-import run from './run';
 
 const pkgDir: any = require('pkg-dir');
 const packagePath = pkgDir.sync(__dirname);

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -16,7 +16,7 @@ export const capabilities = {
 };
 
 // Support running unit tests from a web server that isn't the intern proxy
-export const initialBaseUrl: string | null = (function () {
+export const initialBaseUrl: string | null = (function() {
 	if (typeof location !== 'undefined' && location.pathname.indexOf('__intern/') > -1) {
 		return '/';
 	}
@@ -35,13 +35,13 @@ export const loaderOptions = {
 	// Packages that should be registered with the loader in each testing environment
 	packages: [
 		{ name: 'src', location: '_build/src' },
-		{ name: 'grunt-dojo2', location: 'node_modules/grunt-dojo2'},
+		{ name: 'grunt-dojo2', location: 'node_modules/grunt-dojo2' },
 		{ name: 'tests', location: '_build/tests' }
 	]
 };
 
 // Non-functional test suite(s) to run in each browser
-export const suites = [ 'tests/unit/all' ];
+export const suites = ['tests/unit/all'];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
 export const excludeInstrumentation = /(?:node_modules|bower_components|tests|templates)[\/\\]|dirname/;

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -8,7 +8,8 @@ export function getHelperStub(): Helper {
 		yargs,
 		command: {
 			run: stub().returns(Promise.resolve()),
-			exists: stub().returns(true)
+			exists: stub().returns(true),
+			renderFiles: stub()
 		},
 		configuration: {
 			set: stub().returns(Promise.resolve()),

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -15,7 +15,7 @@ export function getHelperStub(): Helper {
 			get: stub().returns(Promise.resolve())
 		}
 	};
-};
+}
 
 const yargsFunctions = ['demand', 'usage', 'epilog', 'help', 'alias'];
 export function getYargsStub() {

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -6,11 +6,14 @@ export interface Thenable<T> {
 }
 
 export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean> {
-	return promise.then<any>(function () {
-		throw new Error('unexpected code path');
-	}, function () {
-		return true; // expect rejection
-	});
+	return promise.then<any>(
+		function() {
+			throw new Error('unexpected code path');
+		},
+		function() {
+			return true; // expect rejection
+		}
+	);
 }
 
 export function throwImmediatly() {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -13,11 +13,11 @@ registerSuite('main', {
 		});
 
 		mockery.registerMock('./run', {
-			'default': runStub
+			default: runStub
 		});
 
 		mockery.registerMock('./register', {
-			'default': registerStub
+			default: registerStub
 		});
 
 		main = require('../../src/main');

--- a/tests/unit/register.ts
+++ b/tests/unit/register.ts
@@ -19,10 +19,10 @@ registerSuite('register', {
 			const options = sandbox.stub();
 			register(options);
 			assert.strictEqual(options.callCount, 4);
-			assert.isTrue(options.firstCall.calledWithMatch('n', { 'alias': 'name' }));
-			assert.isTrue(options.secondCall.calledWithMatch('s', { 'alias': 'styles' }));
-			assert.isTrue(options.thirdCall.calledWithMatch('t', { 'alias': 'tests' }));
-			assert.isTrue(options.lastCall.calledWithMatch('c', { 'alias': 'component' }));
+			assert.isTrue(options.firstCall.calledWithMatch('n', { alias: 'name' }));
+			assert.isTrue(options.secondCall.calledWithMatch('s', { alias: 'styles' }));
+			assert.isTrue(options.thirdCall.calledWithMatch('t', { alias: 'tests' }));
+			assert.isTrue(options.lastCall.calledWithMatch('c', { alias: 'component' }));
 		}
 	}
 });

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -6,7 +6,7 @@ import * as mockery from 'mockery';
 import { SinonStub, stub } from 'sinon';
 
 type ESModule = {
-	default: any
+	default: any;
 };
 
 const name = 'testAppName';
@@ -21,10 +21,10 @@ let run: any;
 registerSuite('run', {
 	before() {
 		consoleStub = stub(console, 'info');
-		mockery.enable({ 'warnOnUnregistered': false });
+		mockery.enable({ warnOnUnregistered: false });
 		mockery.registerMock('@dojo/cli-create-app/createDir', { default: createDirStub });
 		mockery.registerMock('@dojo/cli-create-app/renderFiles', { default: renderFilesStub });
-		run = (<ESModule> require('../../src/run')).default;
+		run = (<ESModule>require('../../src/run')).default;
 	},
 
 	after() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 		"declaration": false,
 		"module": "umd",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,7 +1,5 @@
 {
-	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
-		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,
@@ -35,9 +37,7 @@
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -57,7 +57,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206