### PR TITLE
Use interfaces from dojo cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "@dojo/cli": "~0.4.2",
     "@dojo/core": "~0.3.0",
     "@dojo/has": "~0.1.1",
-    "@dojo/interfaces": "~0.2.0",
     "@dojo/loader": "~0.1.1",
     "@dojo/shim": "~0.2.3",
     "@types/chalk": "^0.4.31",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Command } from '@dojo/interfaces/cli';
+import { Command } from '@dojo/cli/interfaces';
 import register from './register';
 import run, { CreateWidgetArgs } from './run';
 

--- a/src/register.ts
+++ b/src/register.ts
@@ -1,4 +1,4 @@
-import { OptionsHelper } from '@dojo/interfaces/cli';
+import { OptionsHelper } from '@dojo/cli/interfaces';
 
 export default function(options: OptionsHelper): void {
 	options('n', {

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,5 @@
 import { Argv } from 'yargs';
-import { Helper } from '@dojo/interfaces/cli';
+import { Helper } from '@dojo/cli/interfaces';
 import { join, relative, resolve } from 'path';
 import * as chalk from 'chalk';
 import createDir from '@dojo/cli-create-app/createDir';

--- a/tests/support/testHelper.ts
+++ b/tests/support/testHelper.ts
@@ -1,6 +1,6 @@
 import { stub } from 'sinon';
 import * as yargs from 'yargs';
-import { Helper } from '@dojo/interfaces/cli';
+import { Helper } from '@dojo/cli/interfaces';
 
 export function getHelperStub(): Helper {
 	return {
@@ -8,7 +8,8 @@ export function getHelperStub(): Helper {
 		yargs,
 		command: {
 			run: stub().returns(Promise.resolve()),
-			exists: stub().returns(true)
+			exists: stub().returns(true),
+			renderFiles: stub()
 		},
 		configuration: {
 			set: stub().returns(Promise.resolve()),

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import { getHelperStub } from '../support/testHelper';
-import { Helper } from '@dojo/interfaces/cli';
+import { Helper } from '@dojo/cli/interfaces';
 import * as mockery from 'mockery';
 import { SinonStub, stub } from 'sinon';
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Uses the interfaces from dojo/cli instead of dojo/interfaces.

Addresses: https://github.com/dojo/meta/issues/223