### PR TITLE
Always use POSIX paths for ES imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -824,7 +824,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000807",
+        "caniuse-db": "1.0.30000819",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1153,8 +1153,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000807",
-        "electron-to-chromium": "1.3.33"
+        "caniuse-db": "1.0.30000819",
+        "electron-to-chromium": "1.3.40"
       }
     },
     "buffer": {
@@ -1217,15 +1217,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000807",
+        "caniuse-db": "1.0.30000819",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000807",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000807.tgz",
-      "integrity": "sha1-LwJzLQ8GDmVHLUYIs9UH8le3FlU=",
+      "version": "1.0.30000819",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000819.tgz",
+      "integrity": "sha1-w7fdVZ5ebWPV3Kpiusa9BMdhlwk=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1448,9 +1448,9 @@
       }
     },
     "clone": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
       "dev": true
     },
     "coa": {
@@ -1490,7 +1490,7 @@
       "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
       "dev": true,
       "requires": {
-        "clone": "1.0.3",
+        "clone": "1.0.4",
         "color-convert": "1.9.1",
         "color-string": "0.3.0"
       }
@@ -2204,9 +2204,9 @@
       "integrity": "sha1-zIcsFoiArjxxiXYv1f/ACJbJUYo="
     },
     "electron-to-chromium": {
-      "version": "1.3.33",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.33.tgz",
-      "integrity": "sha1-vwBwPWKnxlI4E2V4w1LWxcBCpUU=",
+      "version": "1.3.40",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.40.tgz",
+      "integrity": "sha1-H71tl779crim+SHcONIkE9L2/d8=",
       "dev": true
     },
     "elegant-spinner": {
@@ -3108,7 +3108,7 @@
         "postcss-cssnext": "2.11.0",
         "postcss-import": "9.1.0",
         "postcss-modules": "0.6.4",
-        "remap-istanbul": "0.10.1",
+        "remap-istanbul": "0.11.0",
         "resolve-from": "2.0.0",
         "shelljs": "0.7.8",
         "tslint": "4.5.1",
@@ -3604,9 +3604,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.11.tgz",
+      "integrity": "sha512-QCR5O2AjjMW8Mo4HyI1ctFcv+O99j/0g367V3YoVnrNw5hkDvAWZD0lWGcc+F4yN3V55USPCVix4efb75HxFfA==",
       "dev": true
     },
     "http-proxy-agent": {
@@ -5172,9 +5172,9 @@
       "dev": true
     },
     "marked": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
-      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.17.tgz",
+      "integrity": "sha512-+AKbNsjZl6jFfLPwHhWmGTqE009wTKn3RTmn9K8oUKHrX/abPJjtcRtXpYB/FFrwPJRUA86LX/de3T0knkPCmQ==",
       "dev": true
     },
     "math-expression-evaluator": {
@@ -8766,50 +8766,45 @@
       "integrity": "sha1-Dxk0E3AM8fgr05Bm7wFtZaShgYE=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.17",
+        "postcss": "6.0.20",
         "postcss-media-query-parser": "0.2.3"
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+          "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
+            "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "4.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-              "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-              "dev": true,
-              "requires": {
-                "has-flag": "2.0.0"
-              }
-            }
+            "supports-color": "5.3.0"
           }
         },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
         "postcss": {
-          "version": "6.0.17",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.17.tgz",
-          "integrity": "sha512-Bl1nybsSzWYbP8O4gAVD8JIjZIul9hLNOPTGBIlVmZNUnNAGL+W0cpYWzVwfImZOwumct4c1SDvSbncVWKtXUw==",
+          "version": "6.0.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.20.tgz",
+          "integrity": "sha512-Opr6usW30Iy0xEDrJywDckRxtylfO7gTGs3Kfb2LdLQlGsUg89fTy0R3Vm1Dub2YHO7MK58avr0p70+uFFHb7A==",
           "dev": true,
           "requires": {
-            "chalk": "2.3.0",
+            "chalk": "2.3.2",
             "source-map": "0.6.1",
-            "supports-color": "5.1.0"
+            "supports-color": "5.3.0"
           }
         },
         "source-map": {
@@ -8819,12 +8814,12 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.1.0.tgz",
-          "integrity": "sha512-Ry0AwkoKjDpVKK4sV4h6o3UJmNRbjYm2uXhwfj3J56lMVdvnUNqzQVRztOOMGQ++w1K/TjNDFvpJk0F/LoeBCQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -9886,9 +9881,9 @@
       }
     },
     "remap-istanbul": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.1.tgz",
-      "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.11.0.tgz",
+      "integrity": "sha512-gQqJ+mW+jF7Hv8hXYO/pIRMz6WgZyrlp3rSxejGXzwqtK9+sNTB/tUSnLWAFTgQx4x5dx0sPDsLvbpZXuZ0omQ==",
       "dev": true,
       "requires": {
         "amdefine": "1.0.1",
@@ -12045,7 +12040,7 @@
         "handlebars": "4.0.5",
         "highlight.js": "9.12.0",
         "lodash": "4.17.5",
-        "marked": "0.3.12",
+        "marked": "0.3.17",
         "minimatch": "3.0.4",
         "progress": "1.1.8",
         "shelljs": "0.7.8",
@@ -12458,7 +12453,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.10",
+        "http-parser-js": "0.4.11",
         "websocket-extensions": "0.1.3"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli-create-widget",
-  "version": "0.1.2-pre",
+  "version": "0.2.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3118,15 +3118,15 @@
       },
       "dependencies": {
         "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
+          "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
           "dev": true
         },
         "diff": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
-          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
           "dev": true
         },
         "execa": {
@@ -3171,8 +3171,8 @@
           "dev": true,
           "requires": {
             "babel-code-frame": "6.26.0",
-            "colors": "1.1.2",
-            "diff": "3.4.0",
+            "colors": "1.2.1",
+            "diff": "3.5.0",
             "findup-sync": "0.3.0",
             "glob": "7.1.2",
             "optimist": "0.6.1",

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,6 +1,6 @@
 import { Argv } from 'yargs';
 import { Helper } from '@dojo/cli/interfaces';
-import { join, relative } from 'path';
+import { join, posix } from 'path';
 import * as chalk from 'chalk';
 import createDir from '@dojo/cli-create-app/createDir';
 import renderFiles from '@dojo/cli-create-app/renderFiles';
@@ -74,9 +74,9 @@ export default async function(helper: Helper, args: CreateWidgetArgs) {
 		name,
 		folderName,
 		includeCustomElement: args.component,
-		componentStylePath: relative(folderName, `${styleRoot}/${folderName}.m.css`),
-		testStylePath: relative(testRoot, `${styleRoot}/${folderName}.m.css`),
-		testComponentPath: relative(testRoot, `${folderName}/${name}`)
+		componentStylePath: posix.relative(folderName, `${styleRoot}/${folderName}.m.css`),
+		testStylePath: posix.relative(testRoot, `${styleRoot}/${folderName}.m.css`),
+		testComponentPath: posix.relative(testRoot, `${folderName}/${name}`)
 	});
 
 	console.info(chalk.green.bold('\nAll done!\n'));

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -4,6 +4,7 @@ import { getHelperStub } from '../support/testHelper';
 import { Helper } from '@dojo/cli/interfaces';
 import * as mockery from 'mockery';
 import { SinonStub, stub } from 'sinon';
+import { join } from 'path';
 
 type ESModule = {
 	default: any;
@@ -58,7 +59,7 @@ registerSuite('run', {
 			const renderFilesArgs = renderFilesStub.args[0];
 
 			assert.deepEqual(renderFilesArgs[0].map((obj: any) => obj.dest), [
-				`${lowerCaseName}/${name}.ts`,
+				`${join(lowerCaseName, name)}.ts`,
 				`${lowerCaseName}.m.css`,
 				`${lowerCaseName}.m.css.d.ts`,
 				`${name}.ts`

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -2,9 +2,9 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import { getHelperStub } from '../support/testHelper';
 import { Helper } from '@dojo/cli/interfaces';
-import * as mockery from 'mockery';
-import { SinonStub, stub } from 'sinon';
 import { join } from 'path';
+import { SinonStub, stub } from 'sinon';
+import * as mockery from 'mockery';
 
 type ESModule = {
 	default: any;
@@ -64,6 +64,19 @@ registerSuite('run', {
 				`${lowerCaseName}.m.css.d.ts`,
 				`${name}.ts`
 			]);
+		},
+
+		async 'Should use correct paths'() {
+			await run(helperStub, Object.assign(args, { component: true, styles: '.', tests: '.' }));
+
+			assert.deepEqual(renderFilesStub.args[0][1] as any, {
+				name: 'testAppName',
+				folderName: 'testappname',
+				includeCustomElement: true,
+				componentStylePath: '../testappname.m.css',
+				testStylePath: 'testappname.m.css',
+				testComponentPath: 'testappname/testAppName'
+			});
 		}
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

ES imports were botched on windows machines due to differences in the output of `path.relative` between win32 and POSIX operating systems. This PR modifies the usage of `path.relative` to use `path.posix.relative` since ES imports should always use POSIX path delimiters.

Resolves #15 
