### PR TITLE
Remove ejs and add tslib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -339,12 +339,6 @@
       "integrity": "sha512-nkT7bd/YM6QRDQjww8PYf0kOj1MvwxQ/WaCinj2Hm1HlL+JqGTm4cDoQeROfiWX/B3SNI1nyLLhLAQpp5sE3hw==",
       "dev": true
     },
-    "@types/ejs": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-2.6.0.tgz",
-      "integrity": "sha512-1ISPltnwvcNU1VTxV0Zusv/nUViHO/S+TUIjiHlvXdmU6e9B/WpCWN6Ewz+fCB7sugdIe5lhsJbbZ6/6+dA1Gg==",
-      "dev": true
-    },
     "@types/events": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
@@ -1679,7 +1673,8 @@
     "ejs": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
-      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ=="
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
+      "dev": true
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -5706,8 +5701,7 @@
     "tslib": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
-      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
-      "dev": true
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
     },
     "tslint": {
       "version": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@dojo/cli": "^3.0.0-alpha.1",
     "@dojo/scripts": "^3.0.0-alpha.6",
     "@dojo/loader": "^2.0.0",
-    "@types/ejs": "^2.3.33",
     "@types/fs-extra": "0.0.34",
     "@types/mockery": "^1.4.29",
     "@types/node": "~9.6.5",
@@ -66,10 +65,10 @@
   "dependencies": {
     "chalk": "~2.4.0",
     "cross-spawn": "^4.0.0",
-    "ejs": "^2.5.2",
     "fs-extra": "^0.30.0",
     "ora": "^0.3.0",
-    "pkg-dir": "^1.0.0"
+    "pkg-dir": "^1.0.0",
+    "tslib": "~1.8.0"
   },
   "lint-staged": {
     "*.{ts,tsx}": [


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`ejs` is no longer needed and `tslib` is now required since `@dojo/cli-create-app` isn't a dependency.
