### PR TITLE
correct link to main dojo cli repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![codecov](https://codecov.io/gh/dojo/cli-create-widget/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/cli-create-widget)
 [![npm version](https://badge.fury.io/js/%40dojo%2Fcli-create-widget.svg)](https://badge.fury.io/js/%40dojo%2Fcli-create-widget)
 
-A [Dojo CLI](https://github/dojo/cli) command that creates a Dojo 2 widget template with an optional custom element descriptor.
+A [Dojo CLI](https://github.com/dojo/cli) command that creates a Dojo 2 widget template with an optional custom element descriptor.
 
 - [Usage](#usage)
 - [Features](#features)


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Clicking the Dojo Cli link in the description and not being taken to the correct location.
