### PR TITLE
Widget root option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2032,11 +2032,11 @@
       "dev": true
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "^3.0.0"
       }
     },
     "for-in": {
@@ -2164,14 +2164,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2186,20 +2184,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2316,8 +2311,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2329,7 +2323,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2344,7 +2337,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2352,14 +2344,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2378,7 +2368,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2459,8 +2448,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2472,7 +2460,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2594,7 +2581,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4025,11 +4011,11 @@
       }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
       "requires": {
-        "p-locate": "^2.0.0",
+        "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
     },
@@ -4060,7 +4046,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -4508,7 +4494,7 @@
     },
     "ora": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/ora/-/ora-0.3.0.tgz",
       "integrity": "sha1-NnoHitJc+wltpQERXrW0AeB9dJU=",
       "requires": {
         "chalk": "^1.1.1",
@@ -4524,7 +4510,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -4582,19 +4568,19 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+      "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "^2.0.0"
       }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "^2.0.0"
       }
     },
     "p-map": {
@@ -4604,9 +4590,9 @@
       "dev": true
     },
     "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
     "package-json": {
       "version": "4.0.1",
@@ -4774,6 +4760,46 @@
       "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
       "requires": {
         "find-up": "^2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
       }
     },
     "platform": {
@@ -5452,7 +5478,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -6023,6 +6049,51 @@
         "which-module": "^2.0.0",
         "y18n": "^3.2.1",
         "yargs-parser": "^8.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
       }
     },
     "yargs-parser": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "chalk": "2.4.1",
     "cross-spawn": "5.1.0",
+    "find-up": "^3.0.0",
     "fs-extra": "5.0.0",
     "ora": "0.3.0",
     "pkg-dir": "2.0.0",

--- a/src/register.ts
+++ b/src/register.ts
@@ -29,4 +29,18 @@ export default function(options: OptionsHelper): void {
 		describe: 'Generate a Custom Element wrapper for your widget',
 		type: 'boolean'
 	});
+	options('f', {
+		alias: 'force',
+		default: false,
+		demand: false,
+		describe: 'Generate element regardless of directory',
+		type: 'boolean'
+	});
+	options('p', {
+		alias: 'prefix',
+		defaultDescription: 'src/<section_folder>',
+		demand: false,
+		describe: 'The location to place your widget',
+		type: 'string'
+	});
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -13,15 +13,19 @@ const packagePath = pkgDir.sync(__dirname);
  * Arguments that can be passed when creating a widget using the Dojo CLI
  *
  * @property component       Generate a Custom Element wrapper
+ * @property force           Create widget regardless of project
  * @property name            Name used for the generated widget
  * @property styles          Path to place generated CSS files
  * @property tests           Path to place generated test files
+ * @property prefix          The location to place your widget
  */
 export interface CreateWidgetArgs extends Argv {
 	component: boolean;
+	force: boolean;
 	name: string;
 	styles: string;
 	tests: string;
+	prefix: string;
 }
 
 function getRenderFilesConfig(args: CreateWidgetArgs, folderName: string, styleRoot: string, testRoot: string) {

--- a/tests/unit/register.ts
+++ b/tests/unit/register.ts
@@ -18,11 +18,14 @@ registerSuite('register', {
 		'Should add correct yargs options'() {
 			const options = sandbox.stub();
 			register(options);
-			assert.strictEqual(options.callCount, 4);
-			assert.isTrue(options.firstCall.calledWithMatch('n', { alias: 'name' }));
-			assert.isTrue(options.secondCall.calledWithMatch('s', { alias: 'styles' }));
-			assert.isTrue(options.thirdCall.calledWithMatch('t', { alias: 'tests' }));
-			assert.isTrue(options.lastCall.calledWithMatch('c', { alias: 'component' }));
+			assert.strictEqual(options.callCount, 6);
+
+			assert.isTrue(options.calledWithMatch('n', { alias: 'name' }), 'one');
+			assert.isTrue(options.calledWithMatch('s', { alias: 'styles' }), 'two');
+			assert.isTrue(options.calledWithMatch('t', { alias: 'tests' }), 'three');
+			assert.isTrue(options.calledWithMatch('c', { alias: 'component' }), 'four');
+			assert.isTrue(options.calledWithMatch('f', { alias: 'force' }), 'five');
+			assert.isTrue(options.calledWithMatch('p', { alias: 'prefix' }), 'six');
 		}
 	}
 });

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -15,6 +15,7 @@ const args = { name };
 const mkdirsSyncStub: SinonStub = stub();
 let renderFilesStub: SinonStub;
 let consoleStub: SinonStub;
+let configurationStub: SinonStub;
 let helperStub: Helper;
 let run: any;
 
@@ -35,6 +36,7 @@ registerSuite('run', {
 	beforeEach() {
 		helperStub = getHelperStub();
 		renderFilesStub = helperStub.command.renderFiles as any;
+		configurationStub = helperStub.configuration.get as any;
 		mkdirsSyncStub.reset();
 	},
 
@@ -116,6 +118,26 @@ registerSuite('run', {
 				testStylePath: 'testappname.m.css',
 				testComponentPath: 'testappname/testAppName'
 			});
+		},
+
+		async 'Should use prefix from .dojorc'() {
+			const testDirName = 'configDir';
+			configurationStub.returns({ prefix: testDirName });
+
+			await run(helperStub, { ...args, component: true, styles: '.', tests: '.' });
+
+			assert.deepEqual(
+				renderFilesStub.args[0][1] as any,
+				{
+					name: 'testAppName',
+					folderName: `${testDirName}/testappname`,
+					includeCustomElement: true,
+					componentStylePath: '../../testappname.m.css',
+					testStylePath: 'testappname.m.css',
+					testComponentPath: 'testappname/testAppName'
+				},
+				''
+			);
 		}
 	}
 });

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -76,7 +76,7 @@ registerSuite('run', {
 
 			assert.deepEqual(renderFilesStub.args[0][1] as any, {
 				name: 'testAppName',
-				folderName: 'testappname',
+				folderName: './testappname',
 				includeCustomElement: true,
 				componentStylePath: '../testappname.m.css',
 				testStylePath: 'testappname.m.css',

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -2,7 +2,6 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import { getHelperStub } from '../support/testHelper';
 import { Helper } from '@dojo/cli/interfaces';
-import { join } from 'path';
 import { SinonStub, stub } from 'sinon';
 import * as mockery from 'mockery';
 
@@ -42,19 +41,21 @@ registerSuite('run', {
 	tests: {
 		async 'Should get directories to create from config'() {
 			await run(helperStub, args);
-			assert.equal(mkdirsSyncStub.callCount, 3);
+			assert.equal(mkdirsSyncStub.callCount, 4);
 
-			assert.isTrue(mkdirsSyncStub.calledWithExactly(lowerCaseName));
-			assert.isTrue(mkdirsSyncStub.calledWithExactly(`${lowerCaseName}/styles`));
-			assert.isTrue(mkdirsSyncStub.calledWithExactly(`${lowerCaseName}/tests/unit`));
+			assert.isTrue(mkdirsSyncStub.calledWithExactly(`./${lowerCaseName}`));
+			assert.isTrue(mkdirsSyncStub.calledWithExactly('.'));
+			assert.isTrue(mkdirsSyncStub.calledWithExactly(`./${lowerCaseName}/styles`));
+			assert.isTrue(mkdirsSyncStub.calledWithExactly(`./${lowerCaseName}/tests/unit`));
 		},
 
 		async 'Should get files to render from config'() {
 			await run(helperStub, { ...args, component: true, styles: '.', tests: '.' });
 
-			assert.equal(mkdirsSyncStub.callCount, 3);
+			assert.equal(mkdirsSyncStub.callCount, 4);
 
-			assert.isTrue(mkdirsSyncStub.calledWithExactly(lowerCaseName));
+			assert.isTrue(mkdirsSyncStub.calledWithExactly(`./${lowerCaseName}`));
+			assert.isTrue(mkdirsSyncStub.calledWithExactly('.'));
 			assert.isTrue(mkdirsSyncStub.calledWithExactly('.'));
 			assert.isTrue(mkdirsSyncStub.calledWithExactly('.'));
 
@@ -63,7 +64,7 @@ registerSuite('run', {
 			const renderFilesArgs = renderFilesStub.args[0];
 
 			assert.deepEqual(renderFilesArgs[0].map((obj: any) => obj.dest), [
-				`${join(lowerCaseName, name)}.ts`,
+				`${lowerCaseName}.ts`,
 				`${lowerCaseName}.m.css`,
 				`${lowerCaseName}.m.css.d.ts`,
 				`${name}.ts`

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -126,18 +126,18 @@ registerSuite('run', {
 
 			await run(helperStub, { ...args, component: true, styles: '.', tests: '.' });
 
-			assert.deepEqual(
-				renderFilesStub.args[0][1] as any,
-				{
-					name: 'testAppName',
-					folderName: `${testDirName}/testappname`,
-					includeCustomElement: true,
-					componentStylePath: '../../testappname.m.css',
-					testStylePath: 'testappname.m.css',
-					testComponentPath: 'testappname/testAppName'
-				},
-				''
-			);
+			assert.deepEqual(renderFilesStub.args[0][1] as any, {
+				name: 'testAppName',
+				folderName: `${testDirName}/testappname`,
+				includeCustomElement: true,
+				componentStylePath: '../../testappname.m.css',
+				testStylePath: 'testappname.m.css',
+				testComponentPath: 'testappname/testAppName'
+			});
+		},
+
+		async 'Should default to project root ./src when not set in .dojorc'() {
+			assert.isTrue(false);
 		}
 	}
 });

--- a/tests/unit/run.ts
+++ b/tests/unit/run.ts
@@ -82,6 +82,40 @@ registerSuite('run', {
 				testStylePath: 'testappname.m.css',
 				testComponentPath: 'testappname/testAppName'
 			});
+		},
+
+		async 'Should use current directory when forced'() {
+			await run(helperStub, {
+				...args,
+				component: true,
+				styles: '.',
+				tests: '.',
+				force: true,
+				prefix: 'other/dir'
+			});
+
+			assert.deepEqual(renderFilesStub.args[0][1] as any, {
+				name: 'testAppName',
+				folderName: './testappname',
+				includeCustomElement: true,
+				componentStylePath: '../testappname.m.css',
+				testStylePath: 'testappname.m.css',
+				testComponentPath: 'testappname/testAppName'
+			});
+		},
+
+		async 'Should use prefix when provided'() {
+			const prefixDir = 'one/two';
+			await run(helperStub, { ...args, component: true, styles: '.', tests: '.', prefix: prefixDir });
+
+			assert.deepEqual(renderFilesStub.args[0][1] as any, {
+				name: 'testAppName',
+				folderName: `${prefixDir}/testappname`,
+				includeCustomElement: true,
+				componentStylePath: '../../../testappname.m.css',
+				testStylePath: 'testappname.m.css',
+				testComponentPath: 'testappname/testAppName'
+			});
 		}
 	}
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:
Running the command `dojo widget create -n name` creates a widget in whatever directory you happen to be in.

* [ ] There is a related issue
* [X] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Added: `--force` option
  - Keeps current functionality, allowing you to create a widget always in your current directory.

Added: `--prefix` option
  - Can provide desired directory through command `dojo create widget -n name --prefix ../otherDir`.
  - Can define prefix directory in `.dojorc` file under `create-widget.prefix`.
  - Falls back to `./src` when previous not provided and `--force` not used.

Questions:
  - Is the wording for the no options provided branch okay?
  - Could the `projectRoot` be something the Helper knows about?

Need Help;
  - I struggled to write a test what to do if the `.dojorc` file does or doesn't exist. I'd like to have another fallback step where it recognizes you're not in a dojo project and prompts to continue with creation. Any help or guidance on that is appreciated.
    - I tried mocking the `find-up` package in a similar way that `fs-extra` was and provide a return value for the mock, but that didn't seem to want to work for me. I'm not sure if I was missing something simple.